### PR TITLE
Link CUDA archive instead of downloads page

### DIFF
--- a/docs/OTVision/gettingstarted/requirements.md
+++ b/docs/OTVision/gettingstarted/requirements.md
@@ -199,4 +199,4 @@ Before using the `convert.py` script, make sure that ffmpeg is installed and ava
 
 If you intend to use **OTVision** on a Windows or Linux PC with a modern
 Nvidia graphics card, download and install version **11.6** of the
-[NVIDIA Cuda Toolkit](https://developer.nvidia.com/cuda-downloads).
+[NVIDIA Cuda Toolkit](https://developer.nvidia.com/cuda-toolkit-archive).


### PR DESCRIPTION
Currently we are behind the latest version, so link to the archive is a better choice, I guess (The archive link on CUDA downloads page is a hidden between other links at the end of the page)