### PR TITLE
Add documentation for expected_duration cli argument in detect

### DIFF
--- a/docs/OTVision/gettingstarted/firstuse.md
+++ b/docs/OTVision/gettingstarted/firstuse.md
@@ -62,7 +62,7 @@ Every command consists of three parts:
     You can specify a file or folder path (in quotation marks) after the
     `-p` (or `--paths`) argument.
 
-    For the detect.py script, you must also specify the expected video duration in seconds after the `--expected_duration` argument.
+    The detect.py script expects an additional argument `--expected_duration`, the expected duration of the video(s) in seconds.
 
     ??? info "Some hints about specifying the paths"
 
@@ -116,7 +116,7 @@ python detect.py -p "path/to/your/video files" --expected_duration <video durati
 where
 
 - `path/to/video files` is either the path to a single video file or a folder containing multiple video files and
-- `video duration [sec]` is the duration of the individual videos to detect.
+- `video duration [sec]` is the duration of the individual videos.
 
 !!! info "Naming convention for your video files"
     The filenames must contain the date and time of the start of the video in the

--- a/docs/OTVision/gettingstarted/firstuse.md
+++ b/docs/OTVision/gettingstarted/firstuse.md
@@ -62,6 +62,8 @@ Every command consists of three parts:
     You can specify a file or folder path (in quotation marks) after the
     `-p` (or `--paths`) argument.
 
+    For the detect.py script, you must also specify the expected video duration in seconds after the `--expected_duration` argument.
+
     ??? info "Some hints about specifying the paths"
 
         You can just drag a file or folder and drop them into the terminal.
@@ -108,11 +110,13 @@ Therefore, we provide the `detect.py` script.
 To detect video files, run the following command after activating your venv:
 
 ``` text
-python detect.py -p "path/to/your/video files"
+python detect.py -p "path/to/your/video files" --expected_duration <video duration [sec]>
 ```
 
-where `path/to/video files` is either the path to a single video file or a folder
-containing multiple video files.
+where
+
+- `path/to/video files` is either the path to a single video file or a folder containing multiple video files and
+- `video duration [sec]` is the duration of the individual videos to detect.
 
 !!! info "Naming convention for your video files"
     The filenames must contain the date and time of the start of the video in the

--- a/docs/OTVision/usage/detect.md
+++ b/docs/OTVision/usage/detect.md
@@ -49,7 +49,7 @@ It has to be specified either using the CLI or in the
 
 `--expected_duration <video duration [sec]>`
 
-Expected duration of the individual videos in seconds (must be all the same).
+Expected duration of each video in seconds (must be all the same).
 This parameter is required to avoid errors if some images are missing in a video.
 
 This parameter is required to run `detect.py`.

--- a/docs/OTVision/usage/detect.md
+++ b/docs/OTVision/usage/detect.md
@@ -3,7 +3,7 @@
 ## Synopsis
 
 ```text
-python  detect.py   [-p paths] [-c config] [-w weights]
+python  detect.py   [-p paths] [--expected_duration] [-c config] [-w weights]
                     [--conf] [--iou] [--chunksize] [--half] [--force]
                     [-o overwrite]
 ```
@@ -40,6 +40,17 @@ or
 `--paths "path/to/video files" "path/to/other video files"`
 
 One or multiple paths to video files or folders containing video files.
+
+This parameter is required to run `detect.py`.
+It has to be specified either using the CLI or in the
+[configuration](../advanced_usage/configuration.md) yaml file.
+
+### expected_duration (required)
+
+`--expected_duration <video duration [sec]>`
+
+Expected duration of the individual videos in seconds (must be all the same).
+This parameter is required to avoid errors if some images are missing in a video.
 
 This parameter is required to run `detect.py`.
 It has to be specified either using the CLI or in the


### PR DESCRIPTION
The expected_duration paramter is required for running the detect script, but was not mentioned on OTDocs